### PR TITLE
fix: Python bytecode cache invalidation in Docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,6 +66,11 @@ COPY config/decay-config.yaml /tmp/decay-config.yaml
 COPY src/skills/server/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
+# Clean up Python bytecode cache after all COPY operations
+# Prevents stale .pyc files from causing inconsistent behavior
+RUN find /app/mcp -type f -name "*.pyc" -delete && \
+    find /app/mcp -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+
 # Set default environment variables (can be overridden at runtime)
 ENV GRAPHITI_GROUP_ID=main \
     SEMAPHORE_LIMIT=10 \


### PR DESCRIPTION
## Summary

Fixes #54

Adds Python bytecode cache cleanup to the Docker build process to prevent stale `.pyc` files from causing inconsistent behavior when patch files are updated.

## Changes

- Added `find` commands to remove `.pyc` files and `__pycache__` directories after all COPY operations
- Positioned after all patch copies but before ENV settings to ensure clean build state
- Uses safe deletion patterns with error suppression for non-existent directories

## Problem Solved

Previously, Python bytecode cache files (`.pyc`) from the build environment could persist through Docker layer rebuilds, causing:
- Stale code execution when patches are updated
- Inconsistency between source code and executed bytecode
- Difficult-to-debug cache misses
- Build artifacts persisting incorrectly across layer caching

## Testing

Manual verification:
1. Build produces clean image with no `.pyc` files in `/app/mcp`
2. Container startup generates fresh bytecode
3. Patch changes are immediately reflected in new builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)